### PR TITLE
Replace `preinstall` and `prepublish` with `prepublishOnly` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@erikwithuhk/html-to-jsx",
   "version": "1.0.2-1",
   "description": "Converts HTML to JSX for use with React",
-  "main": "index.js",
+  "main": "lib/index.js",
   "files": [
     "/lib/**/*.js"
   ],
@@ -11,8 +11,7 @@
     "build:watch": "npm run build -- --watch",
     "clean": "rimraf lib",
     "lint": "eslint ./src",
-    "preinstall": "mv ./lib/* ./ && rimraf ./lib",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run clean && npm run test && npm run build",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:watchAll": "jest --watchAll"


### PR DESCRIPTION
This should fix installation issues we were seeing in nytpi/paidpost-composer. Please try publishing to the NPM registry after merging this PR.