### PR TITLE
wrap jsx key in single quotes

### DIFF
--- a/src/parseStyles.js
+++ b/src/parseStyles.js
@@ -39,8 +39,8 @@ const toJSXValue = value => {
  * @return {string}
  */
 const toJSXString = styles =>
-  Object.keys(styles)
-    .map(key => `${toJSXKey(key)}: ${toJSXValue(styles[key])}`)
+  Object.entries(styles)
+    .map(([key, value]) => `'${toJSXKey(key)}': ${toJSXValue(value)}`)
     .join(', ');
 
 /**


### PR DESCRIPTION
Wraps rendered inline style keys in single quotes to prevent runtime errors from special characters.